### PR TITLE
[Arguments] Added an option to specify the output directory.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ I wrote a blog post about the ideas behind this tool:
 
 Combines traditional web fuzzing techniques with AI-powered path generation to discover hidden endpoints, files, and directories in web applications.
 
+## Information
+
+The original author of **brainstorm** is [@harisec](https://github.com/harisec)/[Invicti Security](https://github.com/Invicti-Security) (thanks!). I only forked the project to modify a few things & add functions that will not be implemented in the main repo (ex: argument for output directory). 
+
 ## Screenshot
 ![screenshot](screenshot.png)
 
@@ -72,19 +76,21 @@ python fuzzer_shortname.py "ffuf -w ./fuzz.txt -u http://example.com/FUZZ" "BENC
 
 #### Main Fuzzer (fuzzer.py)
 ```
---debug             Enable debug mode
---cycles N          Number of fuzzing cycles to run (default: 50)
---model NAME        Ollama model to use (default: qwen2.5-coder:latest)
+-d, --debug             Enable debug mode
+-c, --cycles N          Number of fuzzing cycles to run (default: 50)
+-m, --model NAME        Ollama model to use (default: qwen2.5-coder:latest)
 --prompt-file PATH  Path to prompt file (default: prompts/files.txt)
+-o, --output        The output directory for links & ffuf files (default: /tmp/brainstorm)
 --status-codes LIST Comma-separated list of status codes to consider successful
                    (default: 200,301,302,303,307,308,403,401,500)
 ```
 
 #### Short Filename Fuzzer (fuzzer_shortname.py)
 ```
---debug             Enable debug mode
---cycles N          Number of fuzzing cycles to run (default: 50)
---model NAME        Ollama model to use (default: qwen2.5-coder:latest)
+-d, --debug             Enable debug mode
+-c, --cycles N          Number of fuzzing cycles to run (default: 50)
+-m, --model NAME        Ollama model to use (default: qwen2.5-coder:latest)
+-o, --output        The output directory for links & ffuf files (default: /tmp/brainstorm)
 --status-codes LIST Comma-separated list of status codes to consider successful
 ```
 
@@ -103,8 +109,8 @@ python benchmark.py
 
 ## Output
 
-- Discovered paths are saved to `all_links.txt`
-- Short filenames are saved to `all_filenames.txt`
+- Discovered paths are saved to `all_links.txt`, in the directory specified in the `--output` argument (defaults to /tmp/brainstorm).
+- Short filenames are saved to `all_filenames.txt`, in the directory specified in the `--output` argument (defaults to /tmp/brainstorm).
 - Real-time console output shows progress and discoveries
 
 ## Benchmarking Ollama LLM models

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -157,9 +157,9 @@ def main():
     # Set up argument parser
     parser = argparse.ArgumentParser(description='Web Fuzzer with Ollama integration')
     parser.add_argument('command', help='ffuf command to run')
-    parser.add_argument('--debug', action='store_true', help='Enable debug mode')
-    parser.add_argument('--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
-    parser.add_argument('--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5-coder:latest)')
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug mode')
+    parser.add_argument('-c', '--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
+    parser.add_argument('-m', '--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5-coder:latest)')
     parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files (default: /tmp/brainstorm)')
     parser.add_argument('--prompt-file', default='prompts/files.txt', help='Path to prompt file (default: prompts/files.txt)')
     parser.add_argument('--status-codes', type=str, default='200,301,302,303,307,308,403,401,500',

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -160,7 +160,7 @@ def main():
     parser.add_argument('--debug', action='store_true', help='Enable debug mode')
     parser.add_argument('--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
     parser.add_argument('--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5-coder:latest)')
-    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files.')
+    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files. (default: /tmp/brainstorm)')
     parser.add_argument('--prompt-file', default='prompts/files.txt', help='Path to prompt file (default: prompts/files.txt)')
     parser.add_argument('--status-codes', type=str, default='200,301,302,303,307,308,403,401,500',
                     help='Comma-separated list of status codes to consider as successful (default: 200,301,302,303,307,308,403,401,500)')    

--- a/fuzzer.py
+++ b/fuzzer.py
@@ -160,7 +160,7 @@ def main():
     parser.add_argument('--debug', action='store_true', help='Enable debug mode')
     parser.add_argument('--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
     parser.add_argument('--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5-coder:latest)')
-    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files. (default: /tmp/brainstorm)')
+    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files (default: /tmp/brainstorm)')
     parser.add_argument('--prompt-file', default='prompts/files.txt', help='Path to prompt file (default: prompts/files.txt)')
     parser.add_argument('--status-codes', type=str, default='200,301,302,303,307,308,403,401,500',
                     help='Comma-separated list of status codes to consider as successful (default: 200,301,302,303,307,308,403,401,500)')    

--- a/fuzzer_shortname.py
+++ b/fuzzer_shortname.py
@@ -118,9 +118,9 @@ def main():
     parser = argparse.ArgumentParser(description='Shortname Fuzzer with Ollama integration')
     parser.add_argument('command', help='ffuf command to run')
     parser.add_argument('filename', help='Filename to use in the prompt')
-    parser.add_argument('--debug', action='store_true', help='Enable debug mode')
-    parser.add_argument('--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
-    parser.add_argument('--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5:latest)')
+    parser.add_argument('-d', '--debug', action='store_true', help='Enable debug mode')
+    parser.add_argument('-c', '--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
+    parser.add_argument('-m',  Invicti Security '--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5:latest)')
     parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files (default: /tmp/brainstorm)')
     parser.add_argument('--status-codes', type=str, default='200,301,302,303,307,308,403,401,500',
                     help='Comma-separated list of status codes to consider as successful (default: 200,301,302,303,307,308,403,401,500)')    

--- a/fuzzer_shortname.py
+++ b/fuzzer_shortname.py
@@ -121,7 +121,7 @@ def main():
     parser.add_argument('--debug', action='store_true', help='Enable debug mode')
     parser.add_argument('--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
     parser.add_argument('--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5:latest)')
-    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files. (default: /tmp/brainstorm)')
+    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files (default: /tmp/brainstorm)')
     parser.add_argument('--status-codes', type=str, default='200,301,302,303,307,308,403,401,500',
                     help='Comma-separated list of status codes to consider as successful (default: 200,301,302,303,307,308,403,401,500)')    
 

--- a/fuzzer_shortname.py
+++ b/fuzzer_shortname.py
@@ -121,7 +121,7 @@ def main():
     parser.add_argument('--debug', action='store_true', help='Enable debug mode')
     parser.add_argument('--cycles', type=int, default=50, help='Number of fuzzing cycles to run (default: 50)')
     parser.add_argument('--model', default='qwen2.5-coder:latest', help='Ollama model to use (default: qwen2.5:latest)')
-    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files.')
+    parser.add_argument('-o', '--output', default='/tmp/brainstorm', help='The output directory for links & ffuf files. (default: /tmp/brainstorm)')
     parser.add_argument('--status-codes', type=str, default='200,301,302,303,307,308,403,401,500',
                     help='Comma-separated list of status codes to consider as successful (default: 200,301,302,303,307,308,403,401,500)')    
 

--- a/fuzzer_shortname.py
+++ b/fuzzer_shortname.py
@@ -82,11 +82,11 @@ def run_ffuf(original_cmd, wordlist, target_url, output):
             logger.error(f"ffuf command failed: {result.stderr}")
             return None
         
-        if not os.path.exists('{output}/output.json') or os.stat('{output}/output.json').st_size == 0:
+        if not os.path.exists(f'{output}/output.json') or os.stat(f'{output}/output.json').st_size == 0:
             logger.warning("ffuf produced no output")
             return None        
             
-        with open('{output}/output.json', 'r') as f:
+        with open(f'{output}/output.json', 'r') as f:
             data = json.load(f)
             return data
     except FileNotFoundError:
@@ -203,11 +203,11 @@ def main():
                     logger.debug("\nNew untested filenames suggested by Ollama:")
                     for filename in untested_filenames:
                         logger.debug(f" {filename}")
-                with open('{output}/links.txt', 'w') as f:
+                with open(f'{output}/links.txt', 'w') as f:
                     f.write('\n'.join(untested_filenames))
             
             # Run ffuf with original command
-            ffuf_results = run_ffuf(cmd, '{output}/links.txt', url_match.group(1), output)
+            ffuf_results = run_ffuf(cmd, f'{output}/links.txt', url_match.group(1), output)
             if ffuf_results and 'results' in ffuf_results:
                 if args.debug:
                     logger.debug("\nffuf results:")
@@ -229,7 +229,7 @@ def main():
                     new_discovered_filenames.update(new_discovered)
                 
                 # Save all discovered filenames to file
-                with open('{output}/all_filenames.txt', 'w') as f:
+                with open(f'{output}/all_filenames.txt', 'w') as f:
                     f.write('\n'.join(sorted(all_filenames)))
             
             cycle += 1


### PR DESCRIPTION
Hi,

A small PR to add the `-o` or `--output` option, allowing the user to specify an output directory (defaults to /tmp/brainstorm).

Enables some features of #2.

Cheers.